### PR TITLE
fix: #14 모의 면접 결과 저장 시 몽고DB 타임존 오류 애플리케이션단에서 해결 22-12-02 01:06(백지영)

### DIFF
--- a/models/mockInterviewResult.js
+++ b/models/mockInterviewResult.js
@@ -1,7 +1,5 @@
 const mongoose = require("mongoose");
 const autoIncrement = require("mongoose-sequence")(mongoose);
-const { add } = require("date-fns");
-
 
 const mockInterviewResultSchema = new mongoose.Schema({
   sequence: {
@@ -28,8 +26,8 @@ const mockInterviewResultSchema = new mongoose.Schema({
     type: String,
     // required: true,
   },
-  createdAt: { type: Date, default: add(new Date(), { hours: 9 }) },
-  updatedAt: { type: Date, default: add(new Date(), { hours: 9 }) },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
 });
 
 mockInterviewResultSchema.plugin(autoIncrement, {

--- a/repository/mockInterview.repository.js
+++ b/repository/mockInterview.repository.js
@@ -1,5 +1,6 @@
 const MockInterviews = require("../models/mockInterview");
 const MockInterviewResults = require("../models/mockInterviewResult");
+const { add } = require("date-fns");
 
 class MockInterviewRepository {
   createQuestions = async (category, question) => {
@@ -26,6 +27,8 @@ class MockInterviewRepository {
       number,
       result,
       totalTime,
+      createdAt: add(new Date(), { hours: 9 }),
+      updatedAt: add(new Date(), { hours: 9 }),
     });
     return data;
   };


### PR DESCRIPTION
- 모의 면접 결과 저장 시 몽고DB 타임존 오류 애플리케이션단에서 해결 -> dtae-fns 이용